### PR TITLE
Fix no matches for kind "ClusterRoleBinding", still using v1beta1

### DIFF
--- a/charts/dnslb/templates/rbac.yaml
+++ b/charts/dnslb/templates/rbac.yaml
@@ -22,7 +22,7 @@ rules:
   resources: ["ingresses"]
   verbs: ["list"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:


### PR DESCRIPTION
Simple fix for: Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "ClusterRoleBinding" in version "rbac.authorization.k8s.io/v1beta1"